### PR TITLE
 Fixed catkin package version from 0.0.5 to 0.0.6

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>visualization</name>
-  <version>0.0.5</version>
+  <version>0.0.6</version>
   <description>The visualization package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 


### PR DESCRIPTION
CMake Error at /opt/ros/kinetic/share/catkin/cmake/catkin_python_setup.cmake:79 (message):
  catkin_python_setup() version in setup.py (0.0.6) differs from version in
  package.xml (0.0.5)
Call Stack (most recent call first):
  CMakeLists.txt:16 (catkin_python_setup)