### PR TITLE
Fixing imageio dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,16 @@ python:
 - '3.5'
 - '3.6'
 before_install:
+- sudo apt-get update
+- sudo apt-get install -y curl g++ make
+- pushd ~
+- curl -L http://download.osgeo.org/libspatialindex/spatialindex-src-1.8.5.tar.gz | tar xz
+- cd spatialindex-src-1.8.5
+- ./configure
+- make
+- sudo make install
+- sudo ldconfig
+- popd
 - pip install --upgrade pip setuptools wheel
 - pip install --only-binary=numpy,scipy numpy scipy
 - pip install PyOpenGL

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,15 @@
 Visualization setup file.
 """
 from setuptools import setup
+import sys
+
+def get_imageio_dep():
+    if sys.version[0] == "2":
+        return 'imageio<=2.6.1'
+    return 'imageio'
 
 requirements = [
-    'imageio',
+    get_imageio_dep(),
     'numpy',
     'matplotlib<=2.2.0',
     'trimesh[easy]',


### PR DESCRIPTION
- Latest version of `imageio` does not support Python 2. Manually setting dep to `imageio<=2.6.1` if Python 2 is detected.
- Also fixed `rtree`/`libspatialindex` dep issue.